### PR TITLE
Update load guard for Cataclysm Classic

### DIFF
--- a/LibDualSpec-1.0.lua
+++ b/LibDualSpec-1.0.lua
@@ -31,8 +31,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --]]
 
--- Don't load unless we are Retail or Wrath Classic
-if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE and WOW_PROJECT_ID ~= WOW_PROJECT_WRATH_CLASSIC and (WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC or C_Seasons.GetActiveSeason() ~= 2) then return end
+-- Don't load unless we are Retail or Wrath Classic or Cataclysm Classic
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE and WOW_PROJECT_ID ~= WOW_PROJECT_WRATH_CLASSIC and WOW_PROJECT_ID ~= WOW_PROJECT_CATACLYSM_CLASSIC and (WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC or C_Seasons.GetActiveSeason() ~= 2) then return end
 
 local MAJOR, MINOR = "LibDualSpec-1.0", 22
 assert(LibStub, MAJOR.." requires LibStub")

--- a/LibDualSpec-1.0_Cataclysm.toc
+++ b/LibDualSpec-1.0_Cataclysm.toc
@@ -1,0 +1,11 @@
+## Interface: 40400
+## LoadOnDemand: 1
+## Title: Lib: DualSpec-1.0
+## Version: @project-version@
+## X-Date: @project-date-iso@
+## Notes: Adds spec switching support to individual AceDB-3.0 databases.
+## Author: Adirelle, Nebula
+## OptionalDeps: Ace3
+
+LibStub.lua
+LibDualSpec-1.0.lua


### PR DESCRIPTION
Cataclysm Classic uses WOW_PROJECT_ID == 14 aka WOW_PROJECT_CATACLYSM_CLASSIC.

- extended load guard
- added cataclysm toc

Would be helpful if LibDualSpec-1.0 would load for Cataclysm Classic as well (has Dual-Spec and TalentTabs instead of Specializations - just like Wrath).